### PR TITLE
fix: Fix lib link error, set hompage username, change description

### DIFF
--- a/DeviceLayout.podspec
+++ b/DeviceLayout.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |s|
   s.name             = 'DeviceLayout'
   s.version          = '0.1.0'
-  s.summary          = 'Auto layout can be set differently for each device.'
+  s.summary          = 'Auto Layout can be set differently for each device.'
 
 # This description is used to generate tags and improve search results.
 #   * Think: What does it do? Why did you write it? What is the focus?
@@ -17,8 +17,8 @@ Pod::Spec.new do |s|
 #   * Write the description between the DESC delimiters below.
 #   * Finally, don't worry about the indent, CocoaPods strips it!
 
-  s.description      = 'Auto layout can be set differently for each device.'
-  s.homepage         = 'https://github.com/<GITHUB_USERNAME>/DeviceLayout'
+  s.description      = 'Auto Layout can be set differently for each device. use IBInspectable'
+  s.homepage         = 'https://github.com/cruisediary/DeviceLayout'
   # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'cruisediary' => 'cruzdiary@gmail.com' }


### PR DESCRIPTION
two warning fixed
- summary is same to description
- homepage username empty

<img width="262" alt="screen shot 2016-12-15 at 4 57 27 pm" src="https://cloud.githubusercontent.com/assets/2609775/21216005/c4f1ca0a-c2e7-11e6-98e2-4f46e28a4ffd.png">
